### PR TITLE
Feature: Span across multiple services

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -3,7 +3,7 @@
 const Hoek = require('hoek');
 const OpenTracing = require('opentracing');
 const Package = require('../package.json');
-const { Tags, FORMAT_HTTP_HEADERS } = require('opentracing');
+const { FORMAT_HTTP_HEADERS } = require('opentracing');
 
 
 const internals = {};
@@ -58,15 +58,18 @@ function pickSpanLog (event) {
 function onRequest (request, h) {
   const now = Date.now();
   const headers = {};
-
+  let span = {};
   request.spans = {};
-  const parentSpanContext = tracer.extract(FORMAT_HTTP_HEADERS, req.headers)
-  if(parentSpanContext != null && parentSpanContext!= undefined){
-    const span = request.server.tracer.startSpan('hapi_request', { startTime: now, childOf: parentSpanContext})
-  }else{
-    const span = request.server.tracer.startSpan('hapi_request', { startTime: now });
+
+  const tracer = request.server.tracer;
+  const parentSpanContext = tracer.extract(FORMAT_HTTP_HEADERS, request.headers);
+
+  if (parentSpanContext !== null && parentSpanContext !== undefined) {
+    span = tracer.startSpan('hapi_request', { startTime: now, childOf: parentSpanContext});
+  } else {
+    span = tracer.startSpan('hapi_request', { startTime: now });
   }
-  tracer.inject(span, FORMAT_HTTP_HEADERS, headers); 
+  tracer.inject(span, FORMAT_HTTP_HEADERS, headers);
   span.setTag('method', request.method);
   span.setTag('path', request.path);
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -3,6 +3,7 @@
 const Hoek = require('hoek');
 const OpenTracing = require('opentracing');
 const Package = require('../package.json');
+const { Tags, FORMAT_HTTP_HEADERS } = require('opentracing');
 
 
 const internals = {};
@@ -56,10 +57,16 @@ function pickSpanLog (event) {
 
 function onRequest (request, h) {
   const now = Date.now();
+  const headers = {};
 
   request.spans = {};
-  const span = request.server.tracer.startSpan('hapi_request', { startTime: now });
-
+  const parentSpanContext = tracer.extract(FORMAT_HTTP_HEADERS, req.headers)
+  if(parentSpanContext != null && parentSpanContext!= undefined){
+    const span = request.server.tracer.startSpan('hapi_request', { startTime: now, childOf: parentSpanContext})
+  }else{
+    const span = request.server.tracer.startSpan('hapi_request', { startTime: now });
+  }
+  tracer.inject(span, FORMAT_HTTP_HEADERS, headers); 
   span.setTag('method', request.method);
   span.setTag('path', request.path);
 


### PR DESCRIPTION
Feature Implementation:
Wanted to check if the plugin could provide a feature where the spans could be traced across different micro-services. I want to create a set of spans under single trace for a user experience which internally call multiple services.
Something like microservice A talks to B, so request to A initiates parent span and then the parent span context is passed to service B .
Service B checks if there is a parent span context ( in hapi_request ) to use and proceed as "childof" span or creates a new span instead of childof.