### PR TITLE
preprocess event inputs

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -14,8 +14,31 @@ exports.register = (server, options) => {
   const settings = Object.assign({}, internals.defaults, options);
   const tracer = options.tracer || new OpenTracing.Tracer();
 
-  server.expose('settings', settings);
-  server.decorate('request', 'pickSpanLog', pickSpanLog);
+  // Validate and preparse the event inputs to prevent needing to do it at
+  // runtime.
+  Object.keys(settings).forEach((key) => {
+    // TODO: The input schema should probably not include 'tracer' in the same
+    // object as the event inputs.
+    if (key === 'tracer') {
+      return;
+    }
+
+    Hoek.assert(Array.isArray(settings[key]));
+    settings[key] = settings[key].map((prop) => {
+      Hoek.assert(typeof prop === 'string');
+      const pathParts = prop.split('.');
+
+      // TODO: Should probably throw if the same 'key' is computed, as that
+      // value is used to key an object at runtime, and it would result in
+      // data potentially being overwritten.
+      return {
+        fullPath: prop,
+        key: pathParts[pathParts.length - 1]
+      };
+    });
+  });
+
+  server.decorate('request', 'pickSpanLog', createPickSpanLog(settings));
   server.decorate('request', 'span', requestSpan);
   server.decorate('server', 'tracer', tracer);
   server.ext('onRequest', onRequest);
@@ -36,23 +59,24 @@ internals.defaults = {
   onPreResponse: ['info']
 };
 
-function pickSpanLog (event) {
-  const request = this;
+function createPickSpanLog (settings) {
+  const pickSpanLog = function (event) {
+    const request = this;
+    const result = {};
+    const propKeyPaths = settings[event];
 
-  const result = {};
-  const propKeyPaths = request.server.plugins.traci.settings[event];
-  if (propKeyPaths === undefined) {
+    if (propKeyPaths === undefined) {
+      return result;
+    }
+
+    for (const keyPath of propKeyPaths) {
+      result[keyPath.key] = Hoek.reach(request, keyPath.fullPath);
+    }
+
     return result;
-  }
+  };
 
-  for (const keyPath of propKeyPaths) {
-    // Select the last key as the key for this property
-    const key = keyPath.split('.').reverse()[0];
-    const value = Hoek.reach(request, keyPath);
-    result[key] = value;
-  }
-
-  return result;
+  return pickSpanLog;
 }
 
 function onRequest (request, h) {


### PR DESCRIPTION
This commit preprocesses the event inputs so that they are faster to work with at runtime. It also removes public access to the settings object, as it is no longer necessary.